### PR TITLE
Added INL2States custom msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_message_files(
   GNSSEphemeris.msg
   GNSSObservation.msg
   GNSSObsVec.msg
+  INL2States.msg
 )
 
 add_service_files(

--- a/include/inertial_sense.h
+++ b/include/inertial_sense.h
@@ -25,6 +25,7 @@
 #include "inertial_sense/GlonassEphemeris.h"
 #include "inertial_sense/GNSSObservation.h"
 #include "inertial_sense/GNSSObsVec.h"
+#include "inertial_sense/INL2States.h"
 #include "nav_msgs/Odometry.h"
 #include "std_srvs/Trigger.h"
 #include "std_msgs/Header.h"
@@ -95,6 +96,9 @@ public:
   void INS1_callback(const ins_1_t* const msg);
   void INS2_callback(const ins_2_t* const msg);
 //  void INS_variance_callback(const inl2_variance_t* const msg);
+
+  ros_stream_t INL2_states_;
+  void INL2_states_callback(const inl2_states_t* const msg);
 
   ros_stream_t IMU_;
   void IMU_callback(const dual_imu_t* const msg);
@@ -195,6 +199,7 @@ public:
   inertial_sense::GPS gps_msg;
   geometry_msgs::Vector3Stamped gps_velEcef;
   inertial_sense::GPSInfo gps_info_msg;
+  inertial_sense::INL2States inl2_states_msg;
 
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;

--- a/msg/INL2States.msg
+++ b/msg/INL2States.msg
@@ -1,0 +1,9 @@
+Header header                       # GPS time of week (since Sunday morning) in seconds
+geometry_msgs/Quaternion quatEcef   # Quaternion body rotation with respect to ECEF
+geometry_msgs/Vector3 velEcef       # (m/s) Velocity in ECEF frame
+geometry_msgs/Vector3 posEcef       # (m) Position in ECEF frame
+geometry_msgs/Vector3 gyroBias      # (rad/s) Gyro bias
+geometry_msgs/Vector3 accelBias     # (m/s^2) Accelerometer bias
+float32 baroBias                    # (m) Barometer bias
+float32 magDec                      # (rad) Magnetic declination
+float32 magInc                      # (rad) Magnetic inclination

--- a/src/inertial_sense.cpp
+++ b/src/inertial_sense.cpp
@@ -62,6 +62,14 @@ void InertialSenseROS::configure_data_streams()
     SET_CALLBACK(DID_DUAL_IMU, dual_imu_t, IMU_callback);
   }
 
+  // Set up the IMU bias ROS stream
+  nh_private_.param<bool>("stream_INL2_states", INL2_states_.enabled, false);
+  if (INL2_states_.enabled)
+  {
+    INL2_states_.pub = nh_.advertise<inertial_sense::INL2States>("inl2_states", 1);
+    SET_CALLBACK(DID_INL2_STATES, inl2_states_t, INL2_states_callback);
+  }
+
   // Set up the GPS ROS stream - we always need GPS information for time sync, just don't always need to publish it
   nh_private_.param<bool>("stream_GPS", GPS_.enabled, false);
   if (GPS_.enabled)
@@ -343,6 +351,44 @@ void InertialSenseROS::INS2_callback(const ins_2_t * const msg)
   odom_msg.twist.twist.angular.z = imu1_msg.angular_velocity.z;
   if (INS_.enabled)
     INS_.pub.publish(odom_msg);
+}
+
+
+void InertialSenseROS::INL2_states_callback(const inl2_states_t* const msg)
+{
+  inl2_states_msg.header.stamp = ros_time_from_tow(msg->timeOfWeek);
+  inl2_states_msg.header.frame_id = frame_id_;
+
+  inl2_states_msg.quatEcef.w = msg->qe2b[0];
+  inl2_states_msg.quatEcef.x = msg->qe2b[1];
+  inl2_states_msg.quatEcef.y = msg->qe2b[2];
+  inl2_states_msg.quatEcef.z = msg->qe2b[3];
+
+  inl2_states_msg.velEcef.x = msg->ve[0];
+  inl2_states_msg.velEcef.y = msg->ve[1];
+  inl2_states_msg.velEcef.z = msg->ve[2];
+
+  inl2_states_msg.posEcef.x = msg->ecef[0];
+  inl2_states_msg.posEcef.y = msg->ecef[1];
+  inl2_states_msg.posEcef.z = msg->ecef[2];
+
+  inl2_states_msg.gyroBias.x = msg->biasPqr[0];
+  inl2_states_msg.gyroBias.y = msg->biasPqr[1];
+  inl2_states_msg.gyroBias.z = msg->biasPqr[2];
+
+  inl2_states_msg.accelBias.x = msg->biasAcc[0];
+  inl2_states_msg.accelBias.y = msg->biasAcc[1];
+  inl2_states_msg.accelBias.z = msg->biasAcc[2];
+
+  inl2_states_msg.baroBias = msg->biasBaro;
+  inl2_states_msg.magDec = msg->magDec;
+  inl2_states_msg.magInc = msg->magInc;
+
+  // Use custom INL2 states message
+  if(INL2_states_.enabled)
+  {
+    INL2_states_.pub.publish(inl2_states_msg);
+  }
 }
 
 


### PR DESCRIPTION
Get stream of INL2 states messages, which includes gyro/accel biases. Enable the ros param `stream_INL2_states` to get the topic `inl2_states` with the custom msg type `inertial_sense/INL2States.msg`