### PR TITLE
Rename ins base_link to avoid collisions with Bandicoot

### DIFF
--- a/src/inertial_sense_ros.cpp
+++ b/src/inertial_sense_ros.cpp
@@ -432,7 +432,7 @@ void InertialSenseROS::INS2_callback(const ins_2_t * const msg)
     tf::quaternionMsgToTF(odom_msg.pose.pose.orientation, q);
     transform.setRotation(q);
 
-    br.sendTransform(tf::StampedTransform(transform, ros::Time::now(), "ins", "base_link_ins"));
+    br.sendTransform(tf::StampedTransform(transform, ros::Time::now(), "ins", "ins_base_link"));
   }
 
   if (INS_.enabled)

--- a/src/inertial_sense_ros.cpp
+++ b/src/inertial_sense_ros.cpp
@@ -415,7 +415,7 @@ void InertialSenseROS::INS2_callback(const ins_2_t * const msg)
     tf::quaternionMsgToTF(odom_msg.pose.pose.orientation, q);
     transform.setRotation(q);
 
-    br.sendTransform(tf::StampedTransform(transform, ros::Time::now(), "ins", "base_link"));
+    br.sendTransform(tf::StampedTransform(transform, ros::Time::now(), "ins", "base_link_ins"));
   }
 
   if (INS_.enabled)


### PR DESCRIPTION
Rename ros tf frame to avoid naming collisions with Bandicoot's `base_link`