### PR TITLE
Fix GPS invalid time of week offset on time of week wrap 

### DIFF
--- a/src/inertial_sense_ros.cpp
+++ b/src/inertial_sense_ros.cpp
@@ -512,7 +512,7 @@ void InertialSenseROS::GPS_pos_callback(const gps_pos_t * const msg)
   GPS_towOffset_ = msg->towOffset;
   if (GPS_.enabled && msg->status&GPS_STATUS_FIX_MASK)
   {
-    gps_msg.header.stamp = ros_time_from_week_and_tow(msg->week, msg->timeOfWeekMs/1e3);
+    gps_msg.header.stamp = ros_time_from_week_and_tow(msg->week, msg->timeOfWeekMs/1.0e3);
     gps_msg.week = msg->week;
     gps_msg.fix_type = msg->status & GPS_STATUS_FIX_MASK;
     gps_msg.header.frame_id =frame_id_;
@@ -534,9 +534,9 @@ void InertialSenseROS::GPS_pos_callback(const gps_pos_t * const msg)
 
 void InertialSenseROS::GPS_vel_callback(const gps_vel_t * const msg)
 {
-	if (GPS_.enabled && GPS_towOffset_ > 0.001)
+	if (GPS_.enabled && abs(GPS_towOffset_) > 0.001)
 	{
-		gps_velEcef.header.stamp = ros_time_from_week_and_tow(GPS_week_, msg->timeOfWeekMs/1e3);
+		gps_velEcef.header.stamp = ros_time_from_week_and_tow(GPS_week_, msg->timeOfWeekMs/1.0e3);
 		gps_velEcef.vector.x = msg->vel[0];
 		gps_velEcef.vector.y = msg->vel[1];
 		gps_velEcef.vector.z = msg->vel[2];
@@ -546,7 +546,8 @@ void InertialSenseROS::GPS_vel_callback(const gps_vel_t * const msg)
 
 void InertialSenseROS::publishGPS()
 {
-  if (abs((gps_velEcef.header.stamp - gps_msg.header.stamp).toSec()) < 2e-3)
+  double dt = (gps_velEcef.header.stamp - gps_msg.header.stamp).toSec();
+  if (abs(dt) < 2.0e-3)
 	{
 		gps_msg.velEcef = gps_velEcef.vector;
 		GPS_.pub.publish(gps_msg);
@@ -564,7 +565,7 @@ void InertialSenseROS::strobe_in_time_callback(const strobe_in_time_t * const ms
   if (strobe_pub_.getTopic().empty())
     strobe_pub_ = nh_.advertise<std_msgs::Header>("strobe_time", 1);
   
-  if (GPS_towOffset_ > 0.001)
+  if (abs(GPS_towOffset_) > 0.001)
   {
     std_msgs::Header strobe_msg;
     strobe_msg.stamp = ros_time_from_week_and_tow(msg->week, msg->timeOfWeekMs * 1e-3);
@@ -575,7 +576,7 @@ void InertialSenseROS::strobe_in_time_callback(const strobe_in_time_t * const ms
 
 void InertialSenseROS::GPS_info_callback(const gps_sat_t* const msg)
 {
-  if(GPS_towOffset_ < 0.001)
+  if(abs(GPS_towOffset_) < 0.001)
   { // Wait for valid msg->timeOfWeekMs
     return;
   }
@@ -635,7 +636,7 @@ void InertialSenseROS::preint_IMU_callback(const preintegrated_imu_t * const msg
 
 void InertialSenseROS::RTK_Misc_callback(const gps_rtk_misc_t* const msg)
 {
-  if (RTK_.enabled && GPS_towOffset_ > 0.001)
+  if (RTK_.enabled && abs(GPS_towOffset_) > 0.001)
   {
     inertial_sense_ros::RTKInfo rtk_info;
     rtk_info.header.stamp = ros_time_from_week_and_tow(GPS_week_, msg->timeOfWeekMs/1000.0);
@@ -660,7 +661,7 @@ void InertialSenseROS::RTK_Misc_callback(const gps_rtk_misc_t* const msg)
 
 void InertialSenseROS::RTK_Rel_callback(const gps_rtk_rel_t* const msg)
 {
-  if (RTK_.enabled && GPS_towOffset_ > 0.001)
+  if (RTK_.enabled && abs(GPS_towOffset_) > 0.001)
   {
     inertial_sense_ros::RTKRel rtk_rel;
     rtk_rel.header.stamp = ros_time_from_week_and_tow(GPS_week_, msg->timeOfWeekMs/1000.0);
@@ -1028,7 +1029,7 @@ ros::Time InertialSenseROS::ros_time_from_week_and_tow(const uint32_t week, cons
 {
   ros::Time rostime(0, 0);
   //  If we have a GPS fix, then use it to set timestamp
-  if (GPS_towOffset_ > 0.001)
+  if (abs(GPS_towOffset_) > 0.001)
   {
     uint64_t sec = UNIX_TO_GPS_OFFSET + floor(timeOfWeek) + week*7*24*3600;
     uint64_t nsec = (timeOfWeek - floor(timeOfWeek))*1e9;
@@ -1058,7 +1059,7 @@ ros::Time InertialSenseROS::ros_time_from_start_time(const double time)
   ros::Time rostime(0, 0);
   
   //  If we have a GPS fix, then use it to set timestamp
-  if (GPS_towOffset_ > 0.001)
+  if (abs(GPS_towOffset_) > 0.001)
   {
     double timeOfWeek = time + GPS_towOffset_;
     uint64_t sec = (uint64_t)(UNIX_TO_GPS_OFFSET + floor(timeOfWeek) + GPS_week_*7*24*3600);


### PR DESCRIPTION
Fix GPS time of week (TOW) offset bug that didn't handle when GPS time would restart at beginning of week. 