### PR TITLE
Fixed GPS1 (/gps_truth, when enabled) publishing twice.

### DIFF
--- a/src/inertial_sense_ros.cpp
+++ b/src/inertial_sense_ros.cpp
@@ -1524,7 +1524,7 @@ void InertialSenseROS::GPS_vel_callback(eDataIDs DID, const gps_vel_t *const msg
 
 void InertialSenseROS::publishGPS1()
 {
-    double dt = (gps2_velEcef.header.stamp - gps2_msg.header.stamp).toSec();
+    double dt = (gps1_velEcef.header.stamp - gps1_msg.header.stamp).toSec();
     if (abs(dt) < 2.0e-3)
     {
         gps1_msg.velEcef = gps1_velEcef.vector;


### PR DESCRIPTION
GPS1 was using GPS2 timestamps, to pass the delta-time test (between gps_vel and gps_pos timestamps) to determine if it should publish again.